### PR TITLE
Add test in npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,6 +14,7 @@ jobs:
           node-version: 16
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
+      - run: npm run test
       - run: npm publish --access=public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_RELEASE_TOKEN}}


### PR DESCRIPTION
To ensure unit tests are passed before `npm publish`.