### PR TITLE
Update mobile spec and improve smoke tests

### DIFF
--- a/src/generated/mobile/client.ts
+++ b/src/generated/mobile/client.ts
@@ -3,6 +3,15 @@ import FormData from "form-data";
 import { readFileSync } from "fs";
 import {
   Configuration,
+  DescribeTestResult200Response,
+  DescribeTestResult200ResponseTestCaseResultsInner,
+  DescribeTestResult200ResponseTestCaseResultsInnerTestCase,
+  DescribeTestResult200ResponseTestCaseResultsInnerTestCaseBuild,
+  DescribeTestResult200ResponseTestCaseResultsInnerTestCaseCapability,
+  DescribeTestResult200ResponseTestCaseResultsInnerTestCaseEnvironmentVariablesInner,
+  ListTestResults200Response,
+  ListTestResults200ResponseDataInner,
+  ListTestResults200ResponseDataInnerTestPlan,
   RunTestPlan201Response,
   RunTestPlan201ResponseTestPlan,
   RunTestPlan201ResponseTestPlanBuild,
@@ -19,6 +28,10 @@ import {
   TestPlansApiFp,
   TestPlansApiFactory,
   TestPlansApi,
+  TestResultsApiAxiosParamCreator,
+  TestResultsApiFp,
+  TestResultsApiFactory,
+  TestResultsApi,
 } from "./openapi";
 
 export { BASE_PATH as MOBILE_BASE_PATH } from "./openapi/base";
@@ -59,6 +72,7 @@ export class MobileClient {
     });
     this.buildsApi = new BuildsApi(configuration);
     this.testPlansApi = new TestPlansApi(configuration);
+    this.testResultsApi = new TestResultsApi(configuration);
   }
 
   private readonly buildsApi;
@@ -95,6 +109,52 @@ export class MobileClient {
     return this.testPlansApi.runTestPlan(
       testPlanId,
       runTestPlanRequest,
+      options
+    );
+  }
+
+  private readonly testResultsApi;
+
+  /**
+   * Get a test result.
+   * @summary Get a test result
+   * @param {string} projectId ID of the project from which the test results will be obtained.
+   * @param {string} id Test Result ID.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof TestResultsApi
+   */
+  describeTestResult(
+    projectId: string,
+    id: string,
+    options?: AxiosRequestConfig
+  ) {
+    return this.testResultsApi.describeTestResult(projectId, id, options);
+  }
+
+  /**
+   * List test results.
+   * @summary List test results
+   * @param {string} projectId ID of the project from which the list of test results will be retrieved.
+   * @param {number} [page] Page number to be retrieved.
+   * @param {number} [perPage] Number of test results per page.
+   * @param {string} [testPlanId] ID of the test plan.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof TestResultsApi
+   */
+  listTestResults(
+    projectId: string,
+    page?: number,
+    perPage?: number,
+    testPlanId?: string,
+    options?: AxiosRequestConfig
+  ) {
+    return this.testResultsApi.listTestResults(
+      projectId,
+      page,
+      perPage,
+      testPlanId,
       options
     );
   }

--- a/src/generated/mobile/openapi/api.ts
+++ b/src/generated/mobile/openapi/api.ts
@@ -48,6 +48,291 @@ import {
 /**
  *
  * @export
+ * @interface DescribeTestResult200Response
+ */
+export interface DescribeTestResult200Response {
+  /**
+   *
+   * @type {string}
+   * @memberof DescribeTestResult200Response
+   */
+  id?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof DescribeTestResult200Response
+   */
+  status?: string;
+  /**
+   *
+   * @type {number}
+   * @memberof DescribeTestResult200Response
+   */
+  duration?: number | null;
+  /**
+   *
+   * @type {string}
+   * @memberof DescribeTestResult200Response
+   */
+  started_at?: string | null;
+  /**
+   *
+   * @type {string}
+   * @memberof DescribeTestResult200Response
+   */
+  finished_at?: string | null;
+  /**
+   *
+   * @type {string}
+   * @memberof DescribeTestResult200Response
+   */
+  created_at?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof DescribeTestResult200Response
+   */
+  updated_at?: string;
+  /**
+   *
+   * @type {ListTestResults200ResponseDataInnerTestPlan}
+   * @memberof DescribeTestResult200Response
+   */
+  test_plan?: ListTestResults200ResponseDataInnerTestPlan;
+  /**
+   *
+   * @type {Array<DescribeTestResult200ResponseTestCaseResultsInner>}
+   * @memberof DescribeTestResult200Response
+   */
+  test_case_results?: Array<DescribeTestResult200ResponseTestCaseResultsInner>;
+}
+/**
+ *
+ * @export
+ * @interface DescribeTestResult200ResponseTestCaseResultsInner
+ */
+export interface DescribeTestResult200ResponseTestCaseResultsInner {
+  /**
+   *
+   * @type {string}
+   * @memberof DescribeTestResult200ResponseTestCaseResultsInner
+   */
+  id?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof DescribeTestResult200ResponseTestCaseResultsInner
+   */
+  status?: string;
+  /**
+   *
+   * @type {number}
+   * @memberof DescribeTestResult200ResponseTestCaseResultsInner
+   */
+  duration?: number | null;
+  /**
+   *
+   * @type {DescribeTestResult200ResponseTestCaseResultsInnerTestCase}
+   * @memberof DescribeTestResult200ResponseTestCaseResultsInner
+   */
+  test_case?: DescribeTestResult200ResponseTestCaseResultsInnerTestCase;
+}
+/**
+ *
+ * @export
+ * @interface DescribeTestResult200ResponseTestCaseResultsInnerTestCase
+ */
+export interface DescribeTestResult200ResponseTestCaseResultsInnerTestCase {
+  /**
+   *
+   * @type {Array<DescribeTestResult200ResponseTestCaseResultsInnerTestCaseEnvironmentVariablesInner>}
+   * @memberof DescribeTestResult200ResponseTestCaseResultsInnerTestCase
+   */
+  environment_variables?: Array<DescribeTestResult200ResponseTestCaseResultsInnerTestCaseEnvironmentVariablesInner>;
+  /**
+   *
+   * @type {DescribeTestResult200ResponseTestCaseResultsInnerTestCaseBuild}
+   * @memberof DescribeTestResult200ResponseTestCaseResultsInnerTestCase
+   */
+  build?: DescribeTestResult200ResponseTestCaseResultsInnerTestCaseBuild;
+  /**
+   *
+   * @type {DescribeTestResult200ResponseTestCaseResultsInnerTestCaseCapability}
+   * @memberof DescribeTestResult200ResponseTestCaseResultsInnerTestCase
+   */
+  capability?: DescribeTestResult200ResponseTestCaseResultsInnerTestCaseCapability;
+}
+/**
+ *
+ * @export
+ * @interface DescribeTestResult200ResponseTestCaseResultsInnerTestCaseBuild
+ */
+export interface DescribeTestResult200ResponseTestCaseResultsInnerTestCaseBuild {
+  /**
+   *
+   * @type {string}
+   * @memberof DescribeTestResult200ResponseTestCaseResultsInnerTestCaseBuild
+   */
+  id?: string;
+}
+/**
+ *
+ * @export
+ * @interface DescribeTestResult200ResponseTestCaseResultsInnerTestCaseCapability
+ */
+export interface DescribeTestResult200ResponseTestCaseResultsInnerTestCaseCapability {
+  /**
+   *
+   * @type {string}
+   * @memberof DescribeTestResult200ResponseTestCaseResultsInnerTestCaseCapability
+   */
+  os?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof DescribeTestResult200ResponseTestCaseResultsInnerTestCaseCapability
+   */
+  os_version?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof DescribeTestResult200ResponseTestCaseResultsInnerTestCaseCapability
+   */
+  device?: string;
+}
+/**
+ *
+ * @export
+ * @interface DescribeTestResult200ResponseTestCaseResultsInnerTestCaseEnvironmentVariablesInner
+ */
+export interface DescribeTestResult200ResponseTestCaseResultsInnerTestCaseEnvironmentVariablesInner {
+  /**
+   *
+   * @type {string}
+   * @memberof DescribeTestResult200ResponseTestCaseResultsInnerTestCaseEnvironmentVariablesInner
+   */
+  key?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof DescribeTestResult200ResponseTestCaseResultsInnerTestCaseEnvironmentVariablesInner
+   */
+  name?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof DescribeTestResult200ResponseTestCaseResultsInnerTestCaseEnvironmentVariablesInner
+   */
+  value?: string;
+}
+/**
+ *
+ * @export
+ * @interface ListTestResults200Response
+ */
+export interface ListTestResults200Response {
+  /**
+   *
+   * @type {number}
+   * @memberof ListTestResults200Response
+   */
+  total?: number;
+  /**
+   *
+   * @type {Array<ListTestResults200ResponseDataInner>}
+   * @memberof ListTestResults200Response
+   */
+  data?: Array<ListTestResults200ResponseDataInner>;
+}
+/**
+ *
+ * @export
+ * @interface ListTestResults200ResponseDataInner
+ */
+export interface ListTestResults200ResponseDataInner {
+  /**
+   *
+   * @type {string}
+   * @memberof ListTestResults200ResponseDataInner
+   */
+  id?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof ListTestResults200ResponseDataInner
+   */
+  status?: string;
+  /**
+   *
+   * @type {number}
+   * @memberof ListTestResults200ResponseDataInner
+   */
+  duration?: number | null;
+  /**
+   *
+   * @type {string}
+   * @memberof ListTestResults200ResponseDataInner
+   */
+  started_at?: string | null;
+  /**
+   *
+   * @type {string}
+   * @memberof ListTestResults200ResponseDataInner
+   */
+  finished_at?: string | null;
+  /**
+   *
+   * @type {string}
+   * @memberof ListTestResults200ResponseDataInner
+   */
+  created_at?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof ListTestResults200ResponseDataInner
+   */
+  updated_at?: string;
+  /**
+   *
+   * @type {ListTestResults200ResponseDataInnerTestPlan}
+   * @memberof ListTestResults200ResponseDataInner
+   */
+  test_plan?: ListTestResults200ResponseDataInnerTestPlan;
+}
+/**
+ *
+ * @export
+ * @interface ListTestResults200ResponseDataInnerTestPlan
+ */
+export interface ListTestResults200ResponseDataInnerTestPlan {
+  /**
+   *
+   * @type {string}
+   * @memberof ListTestResults200ResponseDataInnerTestPlan
+   */
+  id?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof ListTestResults200ResponseDataInnerTestPlan
+   */
+  name?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof ListTestResults200ResponseDataInnerTestPlan
+   */
+  created_at?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof ListTestResults200ResponseDataInnerTestPlan
+   */
+  updated_at?: string;
+}
+/**
+ *
+ * @export
  * @interface RunTestPlan201Response
  */
 export interface RunTestPlan201Response {
@@ -568,6 +853,318 @@ export class TestPlansApi extends BaseAPI {
   ) {
     return TestPlansApiFp(this.configuration)
       .runTestPlan(testPlanId, runTestPlanRequest, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+}
+
+/**
+ * TestResultsApi - axios parameter creator
+ * @export
+ */
+export const TestResultsApiAxiosParamCreator = function (
+  configuration?: Configuration
+) {
+  return {
+    /**
+     * Get a test result.
+     * @summary Get a test result
+     * @param {string} projectId ID of the project from which the test results will be obtained.
+     * @param {string} id Test Result ID.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    describeTestResult: async (
+      projectId: string,
+      id: string,
+      options: AxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'projectId' is not null or undefined
+      assertParamExists("describeTestResult", "projectId", projectId);
+      // verify required parameter 'id' is not null or undefined
+      assertParamExists("describeTestResult", "id", id);
+      const localVarPath = `/projects/{project_id}/results/{id}`
+        .replace(`{${"project_id"}}`, encodeURIComponent(String(projectId)))
+        .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
+
+      const localVarRequestOptions = {
+        method: "GET",
+        ...baseOptions,
+        ...options,
+      };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication bearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * List test results.
+     * @summary List test results
+     * @param {string} projectId ID of the project from which the list of test results will be retrieved.
+     * @param {number} [page] Page number to be retrieved.
+     * @param {number} [perPage] Number of test results per page.
+     * @param {string} [testPlanId] ID of the test plan.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    listTestResults: async (
+      projectId: string,
+      page?: number,
+      perPage?: number,
+      testPlanId?: string,
+      options: AxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'projectId' is not null or undefined
+      assertParamExists("listTestResults", "projectId", projectId);
+      const localVarPath = `/projects/{project_id}/results`.replace(
+        `{${"project_id"}}`,
+        encodeURIComponent(String(projectId))
+      );
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
+
+      const localVarRequestOptions = {
+        method: "GET",
+        ...baseOptions,
+        ...options,
+      };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication bearerAuth required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      if (page !== undefined) {
+        localVarQueryParameter["page"] = page;
+      }
+
+      if (perPage !== undefined) {
+        localVarQueryParameter["per_page"] = perPage;
+      }
+
+      if (testPlanId !== undefined) {
+        localVarQueryParameter["test_plan_id"] = testPlanId;
+      }
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      };
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+  };
+};
+
+/**
+ * TestResultsApi - functional programming interface
+ * @export
+ */
+export const TestResultsApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator =
+    TestResultsApiAxiosParamCreator(configuration);
+  return {
+    /**
+     * Get a test result.
+     * @summary Get a test result
+     * @param {string} projectId ID of the project from which the test results will be obtained.
+     * @param {string} id Test Result ID.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async describeTestResult(
+      projectId: string,
+      id: string,
+      options?: AxiosRequestConfig
+    ): Promise<
+      (
+        axios?: AxiosInstance,
+        basePath?: string
+      ) => AxiosPromise<DescribeTestResult200Response>
+    > {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.describeTestResult(
+          projectId,
+          id,
+          options
+        );
+      return createRequestFunction(
+        localVarAxiosArgs,
+        globalAxios,
+        BASE_PATH,
+        configuration
+      );
+    },
+    /**
+     * List test results.
+     * @summary List test results
+     * @param {string} projectId ID of the project from which the list of test results will be retrieved.
+     * @param {number} [page] Page number to be retrieved.
+     * @param {number} [perPage] Number of test results per page.
+     * @param {string} [testPlanId] ID of the test plan.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async listTestResults(
+      projectId: string,
+      page?: number,
+      perPage?: number,
+      testPlanId?: string,
+      options?: AxiosRequestConfig
+    ): Promise<
+      (
+        axios?: AxiosInstance,
+        basePath?: string
+      ) => AxiosPromise<ListTestResults200Response>
+    > {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.listTestResults(
+        projectId,
+        page,
+        perPage,
+        testPlanId,
+        options
+      );
+      return createRequestFunction(
+        localVarAxiosArgs,
+        globalAxios,
+        BASE_PATH,
+        configuration
+      );
+    },
+  };
+};
+
+/**
+ * TestResultsApi - factory interface
+ * @export
+ */
+export const TestResultsApiFactory = function (
+  configuration?: Configuration,
+  basePath?: string,
+  axios?: AxiosInstance
+) {
+  const localVarFp = TestResultsApiFp(configuration);
+  return {
+    /**
+     * Get a test result.
+     * @summary Get a test result
+     * @param {string} projectId ID of the project from which the test results will be obtained.
+     * @param {string} id Test Result ID.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    describeTestResult(
+      projectId: string,
+      id: string,
+      options?: any
+    ): AxiosPromise<DescribeTestResult200Response> {
+      return localVarFp
+        .describeTestResult(projectId, id, options)
+        .then((request) => request(axios, basePath));
+    },
+    /**
+     * List test results.
+     * @summary List test results
+     * @param {string} projectId ID of the project from which the list of test results will be retrieved.
+     * @param {number} [page] Page number to be retrieved.
+     * @param {number} [perPage] Number of test results per page.
+     * @param {string} [testPlanId] ID of the test plan.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    listTestResults(
+      projectId: string,
+      page?: number,
+      perPage?: number,
+      testPlanId?: string,
+      options?: any
+    ): AxiosPromise<ListTestResults200Response> {
+      return localVarFp
+        .listTestResults(projectId, page, perPage, testPlanId, options)
+        .then((request) => request(axios, basePath));
+    },
+  };
+};
+
+/**
+ * TestResultsApi - object-oriented interface
+ * @export
+ * @class TestResultsApi
+ * @extends {BaseAPI}
+ */
+export class TestResultsApi extends BaseAPI {
+  /**
+   * Get a test result.
+   * @summary Get a test result
+   * @param {string} projectId ID of the project from which the test results will be obtained.
+   * @param {string} id Test Result ID.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof TestResultsApi
+   */
+  public describeTestResult(
+    projectId: string,
+    id: string,
+    options?: AxiosRequestConfig
+  ) {
+    return TestResultsApiFp(this.configuration)
+      .describeTestResult(projectId, id, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
+
+  /**
+   * List test results.
+   * @summary List test results
+   * @param {string} projectId ID of the project from which the list of test results will be retrieved.
+   * @param {number} [page] Page number to be retrieved.
+   * @param {number} [perPage] Number of test results per page.
+   * @param {string} [testPlanId] ID of the test plan.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof TestResultsApi
+   */
+  public listTestResults(
+    projectId: string,
+    page?: number,
+    perPage?: number,
+    testPlanId?: string,
+    options?: AxiosRequestConfig
+  ) {
+    return TestResultsApiFp(this.configuration)
+      .listTestResults(projectId, page, perPage, testPlanId, options)
       .then((request) => request(this.axios, this.basePath));
   }
 }

--- a/swagger-mobile.yml
+++ b/swagger-mobile.yml
@@ -63,6 +63,250 @@ paths:
                           example: Error message.
         "401":
           description: bad credentials
+  "/projects/{project_id}/results":
+    get:
+      summary: List test results
+      tags:
+        - Test results
+      description: List test results.
+      operationId: listTestResults
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: project_id
+          in: path
+          required: true
+          description:
+            ID of the project from which the list of test results will be
+            retrieved.
+          schema:
+            type: string
+        - name: page
+          in: query
+          required: false
+          description: Page number to be retrieved.
+          schema:
+            type: number
+        - name: per_page
+          in: query
+          required: false
+          description: Number of test results per page.
+          schema:
+            type: number
+        - name: test_plan_id
+          in: query
+          required: false
+          description: ID of the test plan.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: List test results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: number
+                    example: "120"
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          example: jx8tyj
+                        status:
+                          type: string
+                          example: passed
+                        duration:
+                          type: number
+                          nullable: true
+                          example: "10"
+                        started_at:
+                          type: string
+                          nullable: true
+                          example: "2022-06-13T17:06:19.487+09:00"
+                        finished_at:
+                          type: string
+                          nullable: true
+                          example: "2022-06-13T17:06:19.487+09:00"
+                        created_at:
+                          type: string
+                          example: "2022-06-13T17:06:19.487+09:00"
+                        updated_at:
+                          type: string
+                          example: "2022-06-13T17:06:19.487+09:00"
+                        test_plan:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                              example: jx8tyj
+                            name:
+                              type: string
+                              example: E2E Test
+                            created_at:
+                              type: string
+                              example: "2022-06-13T17:06:19.487+09:00"
+                            updated_at:
+                              type: string
+                              example: "2022-06-13T17:06:19.487+09:00"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        message:
+                          type: string
+                          example: Error message.
+        "401":
+          description: bad credentials
+  "/projects/{project_id}/results/{id}":
+    get:
+      summary: Get a test result
+      tags:
+        - Test results
+      description: Get a test result.
+      operationId: describeTestResult
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: project_id
+          in: path
+          required: true
+          description: ID of the project from which the test results will be obtained.
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          description: Test Result ID.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Get a test result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    example: jx8tyj
+                  status:
+                    type: string
+                    example: passed
+                  duration:
+                    type: number
+                    nullable: true
+                    example: "10"
+                  started_at:
+                    type: string
+                    nullable: true
+                    example: "2022-06-13T17:06:19.487+09:00"
+                  finished_at:
+                    type: string
+                    nullable: true
+                    example: "2022-06-13T17:06:19.487+09:00"
+                  created_at:
+                    type: string
+                    example: "2022-06-13T17:06:19.487+09:00"
+                  updated_at:
+                    type: string
+                    example: "2022-06-13T17:06:19.487+09:00"
+                  test_plan:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        example: jx8tyj
+                      name:
+                        type: string
+                        example: E2E Test
+                      created_at:
+                        type: string
+                        example: "2022-06-13T17:06:19.487+09:00"
+                      updated_at:
+                        type: string
+                        example: "2022-06-13T17:06:19.487+09:00"
+                  test_case_results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          example: jx8tyj
+                        status:
+                          type: string
+                          example: passed
+                        duration:
+                          type: number
+                          nullable: true
+                          example: "10"
+                        test_case:
+                          type: object
+                          properties:
+                            environment_variables:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  key:
+                                    type: string
+                                    example: key
+                                  name:
+                                    type: string
+                                    example: name
+                                  value:
+                                    type: string
+                                    example: value
+                            build:
+                              type: object
+                              properties:
+                                id:
+                                  type: string
+                                  example: jx8tyj
+                            capability:
+                              type: object
+                              properties:
+                                os:
+                                  type: string
+                                  example: iOS
+                                os_version:
+                                  type: string
+                                  example: "14.4"
+                                device:
+                                  type: string
+                                  example: iPhone 12 Pro
+        "401":
+          description: bad credentials
+        "404":
+          description: not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        message:
+                          type: string
+                          example: Error message.
   "/test_plans/{test_plan_id}/test_plan_results":
     post:
       summary: Run a test plan

--- a/test/mobile/smoke.test.ts
+++ b/test/mobile/smoke.test.ts
@@ -5,19 +5,54 @@ import { join } from "path";
 
 const mock = new MockAdaptor(axios, { onNoMatch: "throwException" });
 const mockResponse = {};
-const client = new MobileClient("token");
+const token = "token";
+const userAgent = "userAgent";
+const client = new MobileClient(token, { userAgent });
+const headersMatcher = expect.objectContaining({
+  Authorization: `Bearer ${token}`,
+  "User-Agent": userAgent,
+});
 
 describe.each([
   {
     desc: "uploadBuild",
     api: () => client.uploadBuild("id", join(__dirname, "mock.file")),
-    mockOn: () => mock.onPost(MOBILE_BASE_PATH + "/projects/id/builds"),
+    mockOn: () =>
+      mock.onPost(
+        MOBILE_BASE_PATH + "/projects/id/builds",
+        undefined,
+        headersMatcher
+      ),
   },
   {
     desc: "runTestPlan",
     api: () => client.runTestPlan("id", {}),
     mockOn: () =>
-      mock.onPost(MOBILE_BASE_PATH + "/test_plans/id/test_plan_results"),
+      mock.onPost(
+        MOBILE_BASE_PATH + "/test_plans/id/test_plan_results",
+        undefined,
+        headersMatcher
+      ),
+  },
+  {
+    desc: "describeTestResult",
+    api: () => client.describeTestResult("id", "id2"),
+    mockOn: () =>
+      mock.onGet(
+        MOBILE_BASE_PATH + "/projects/id/results/id2",
+        undefined,
+        headersMatcher
+      ),
+  },
+  {
+    desc: "listTestResults",
+    api: () => client.listTestResults("id"),
+    mockOn: () =>
+      mock.onGet(
+        MOBILE_BASE_PATH + "/projects/id/results",
+        undefined,
+        headersMatcher
+      ),
   },
 ])("$desc", ({ api, mockOn }) => {
   test("success", async () => {

--- a/test/web/smoke.test.ts
+++ b/test/web/smoke.test.ts
@@ -4,28 +4,54 @@ import MockAdaptor from "axios-mock-adapter";
 
 const mock = new MockAdaptor(axios, { onNoMatch: "throwException" });
 const mockResponse = {};
-const client = new WebClient("token");
+const token = "token";
+const userAgent = "userAgent";
+const client = new WebClient(token, { userAgent });
+const headersMatcher = expect.objectContaining({
+  Authorization: `Bearer ${token}`,
+  "User-Agent": userAgent,
+});
 
 describe.each([
   {
     desc: "listCapabilities",
     api: () => client.listCapabilities(1),
-    mockOn: () => mock.onGet(WEB_BASE_PATH + "/projects/1/capabilities"),
+    mockOn: () =>
+      mock.onGet(
+        WEB_BASE_PATH + "/projects/1/capabilities",
+        undefined,
+        headersMatcher
+      ),
   },
   {
     desc: "describeResult",
     api: () => client.describeResult(1, 2),
-    mockOn: () => mock.onGet(WEB_BASE_PATH + "/projects/1/results/2"),
+    mockOn: () =>
+      mock.onGet(
+        WEB_BASE_PATH + "/projects/1/results/2",
+        undefined,
+        headersMatcher
+      ),
   },
   {
     desc: "listResults",
     api: () => client.listResults(1),
-    mockOn: () => mock.onGet(WEB_BASE_PATH + "/projects/1/results"),
+    mockOn: () =>
+      mock.onGet(
+        WEB_BASE_PATH + "/projects/1/results",
+        undefined,
+        headersMatcher
+      ),
   },
   {
     desc: "describeScenario",
     api: () => client.describeScenario(1, 2),
-    mockOn: () => mock.onGet(WEB_BASE_PATH + "/projects/1/scenarios/2"),
+    mockOn: () =>
+      mock.onGet(
+        WEB_BASE_PATH + "/projects/1/scenarios/2",
+        undefined,
+        headersMatcher
+      ),
   },
   {
     desc: "executeScenarios",
@@ -34,17 +60,28 @@ describe.each([
         capabilities: [],
         scenarios: [],
       }),
-    mockOn: () => mock.onPost(WEB_BASE_PATH + "/projects/1/execute_scenarios"),
+    mockOn: () =>
+      mock.onPost(
+        WEB_BASE_PATH + "/projects/1/execute_scenarios",
+        undefined,
+        headersMatcher
+      ),
   },
   {
     desc: "listScenarios",
     api: () => client.listScenarios(1),
-    mockOn: () => mock.onGet(WEB_BASE_PATH + "/projects/1/scenarios"),
+    mockOn: () =>
+      mock.onGet(
+        WEB_BASE_PATH + "/projects/1/scenarios",
+        undefined,
+        headersMatcher
+      ),
   },
   {
     desc: "executeSchedule",
     api: () => client.executeSchedule(1),
-    mockOn: () => mock.onPost(WEB_BASE_PATH + "/schedules/1"),
+    mockOn: () =>
+      mock.onPost(WEB_BASE_PATH + "/schedules/1", undefined, headersMatcher),
   },
   {
     desc: "createUrlReplacement",
@@ -53,18 +90,32 @@ describe.each([
         pattern_url: "",
         replacement_url: "",
       }),
-    mockOn: () => mock.onPost(WEB_BASE_PATH + "/test_plans/1/url_replacements"),
+    mockOn: () =>
+      mock.onPost(
+        WEB_BASE_PATH + "/test_plans/1/url_replacements",
+        undefined,
+        headersMatcher
+      ),
   },
   {
     desc: "deleteUrlReplacement",
     api: () => client.deleteUrlReplacement(1, 2),
     mockOn: () =>
-      mock.onDelete(WEB_BASE_PATH + "/test_plans/1/url_replacements/2"),
+      mock.onDelete(
+        WEB_BASE_PATH + "/test_plans/1/url_replacements/2",
+        undefined,
+        headersMatcher
+      ),
   },
   {
     desc: "listUrlReplacements",
     api: () => client.listUrlReplacements(1),
-    mockOn: () => mock.onGet(WEB_BASE_PATH + "/test_plans/1/url_replacements"),
+    mockOn: () =>
+      mock.onGet(
+        WEB_BASE_PATH + "/test_plans/1/url_replacements",
+        undefined,
+        headersMatcher
+      ),
   },
   {
     desc: "updateUrlReplacement",


### PR DESCRIPTION
Recently, Autify for Mobile released new apis i.e. `listTestResults` and
`describeTestResult`. This commit follows the change by updating
the OpenAPI definition and generating the code.

Also, we adds header validation to smoke tests so that we can detect
if the spec misses authorization headers.