### PR TITLE
Use stream with formdata

### DIFF
--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -24,14 +24,14 @@ const writeClientSource = (
       `
 import {AxiosRequestConfig} from 'axios'
 import FormData from 'form-data'
-import {readFileSync} from 'fs';
+import {createReadStream} from 'fs';
 
 export {BASE_PATH as ${service.toUpperCase()}_BASE_PATH} from './openapi/base'
 
 class CustomFormData extends FormData {
   append(key: string, filename: any) {
-    const blob = readFileSync(filename)
-    super.append(key, blob, {filename})
+    const stream = createReadStream(filename);
+    super.append(key, stream, {filename})
   }
 }
 
@@ -55,6 +55,8 @@ export class ${clientClassName} {
           "User-Agent": userAgent,
         },
       }),
+      maxBodyLength: Number.POSITIVE_INFINITY,
+      maxContentLength: Number.POSITIVE_INFINITY,
     }
     const configuration = new Configuration({accessToken, basePath, formDataCtor: CustomFormData, baseOptions})
   }

--- a/src/generated/mobile/client.ts
+++ b/src/generated/mobile/client.ts
@@ -1,6 +1,6 @@
 import { AxiosRequestConfig } from "axios";
 import FormData from "form-data";
-import { readFileSync } from "fs";
+import { createReadStream } from "fs";
 import {
   Configuration,
   DescribeTestResult200Response,
@@ -38,8 +38,8 @@ export { BASE_PATH as MOBILE_BASE_PATH } from "./openapi/base";
 
 class CustomFormData extends FormData {
   append(key: string, filename: any) {
-    const blob = readFileSync(filename);
-    super.append(key, blob, { filename });
+    const stream = createReadStream(filename);
+    super.append(key, stream, { filename });
   }
 }
 
@@ -63,6 +63,8 @@ export class MobileClient {
           "User-Agent": userAgent,
         },
       }),
+      maxBodyLength: Number.POSITIVE_INFINITY,
+      maxContentLength: Number.POSITIVE_INFINITY,
     };
     const configuration = new Configuration({
       accessToken,

--- a/src/generated/web/client.ts
+++ b/src/generated/web/client.ts
@@ -1,6 +1,6 @@
 import { AxiosRequestConfig } from "axios";
 import FormData from "form-data";
-import { readFileSync } from "fs";
+import { createReadStream } from "fs";
 import {
   Configuration,
   Capability,
@@ -75,8 +75,8 @@ export { BASE_PATH as WEB_BASE_PATH } from "./openapi/base";
 
 class CustomFormData extends FormData {
   append(key: string, filename: any) {
-    const blob = readFileSync(filename);
-    super.append(key, blob, { filename });
+    const stream = createReadStream(filename);
+    super.append(key, stream, { filename });
   }
 }
 
@@ -100,6 +100,8 @@ export class WebClient {
           "User-Agent": userAgent,
         },
       }),
+      maxBodyLength: Number.POSITIVE_INFINITY,
+      maxContentLength: Number.POSITIVE_INFINITY,
     };
     const configuration = new Configuration({
       accessToken,


### PR DESCRIPTION
Since the previous code reads all the file content to memory, it breaks `axios-logger` because it stringifies.

Instead, this commit uses stream data so that the logger won't write the file content. Also, it reduces memory usage as well.

Additionally, we set unlimited file size to avoid the client side failure. If the file size is too large, the server side will reject.

Close #65 