### PR TITLE
Stick @types/node version to 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@openapitools/openapi-generator-cli": "^2.5.1",
         "@types/debug": "^4.1.7",
         "@types/jest": "^28.1.1",
-        "@types/node": "^18.0.0",
+        "@types/node": "^16.0.0",
         "@typescript-eslint/eslint-plugin": "^5.27.1",
         "@typescript-eslint/parser": "^5.27.1",
         "axios-mock-adapter": "^1.21.1",
@@ -1444,9 +1444,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.8.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.3.tgz",
-      "integrity": "sha512-0os9vz6BpGwxGe9LOhgP/ncvYN5Tx1fNcd2TM3rD/aCGBkysb+ZWpXEocG24h6ZzOi13+VB8HndAQFezsSOw1w==",
+      "version": "16.11.66",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.66.tgz",
+      "integrity": "sha512-+xvMrGl3eAygKcf5jm+4zA4tbfEgmKM9o6/glTmN0RFVdu2VuFXMYYtRmuv3zTGCgAYMnEZLde3B7BTp+Yxcig==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -7643,9 +7643,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.8.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.3.tgz",
-      "integrity": "sha512-0os9vz6BpGwxGe9LOhgP/ncvYN5Tx1fNcd2TM3rD/aCGBkysb+ZWpXEocG24h6ZzOi13+VB8HndAQFezsSOw1w==",
+      "version": "16.11.66",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.66.tgz",
+      "integrity": "sha512-+xvMrGl3eAygKcf5jm+4zA4tbfEgmKM9o6/glTmN0RFVdu2VuFXMYYtRmuv3zTGCgAYMnEZLde3B7BTp+Yxcig==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@openapitools/openapi-generator-cli": "^2.5.1",
     "@types/debug": "^4.1.7",
     "@types/jest": "^28.1.1",
-    "@types/node": "^18.0.0",
+    "@types/node": "^16.0.0",
     "@typescript-eslint/eslint-plugin": "^5.27.1",
     "@typescript-eslint/parser": "^5.27.1",
     "axios-mock-adapter": "^1.21.1",


### PR DESCRIPTION
Since LTS of Node.js is 16, we should keep the types to 16 as well.