### PR TITLE
Fix Accept-Encoding header to null

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,4 @@
+import axios from "axios";
+
+// Axios set several default encodings but we'd like to keep it as plain text since it's JSON API.
+axios.defaults.headers["Accept-Encoding"] = null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import "./config";
 import "./debug";
 
 export { WebClient, WEB_BASE_PATH } from "./generated/web/client";


### PR DESCRIPTION
Starting from Axios v1, it set several default Accept-Encoding header. However, we want to keep it as plain text since our API is JSON.