### PR TITLE
Align `lib` with `autify-cli` in `tsconfig.json`

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         node: [12, 14, 16, 18]
+      fail-fast: false
     name: Node ${{ matrix.node }} build
     steps:
       - uses: actions/checkout@v3
@@ -27,6 +28,7 @@ jobs:
     strategy:
       matrix:
         node: [12, 14, 16, 18]
+      fail-fast: false
     name: Node ${{ matrix.node }} test
     steps:
       - uses: actions/checkout@v3

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "declaration": true,
     "importHelpers": true,
     "module": "commonjs",
+    "lib": ["es2021"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,


### PR DESCRIPTION
This package is mainly used by `autify-cli` but there are a slight
differences between them and we couldn't capture an issue only
happens on `autify-cli`'s build.

This commit adds `lib` property to align with `autify-cli` so that
we can capture future regressions on this repository's build instead.

Along with it, we update GitHub Actions not to fail fast to validate
all environments regardless of any early failures.