### PR TITLE
Revert `axios` to `1.1.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.2.0",
+        "axios": "~1.1.3",
         "axios-logger": "^2.6.1",
         "debug": "^4.3.4",
         "form-data": "^4.0.0",
@@ -1899,9 +1899,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.0.tgz",
-      "integrity": "sha512-zT7wZyNYu3N5Bu0wuZ6QccIf93Qk1eV8LOewxgjOZFd2DenOs98cJ7+Y6703d0wkaXGY6/nZd4EweJaHz9uzQw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -7967,9 +7967,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.0.tgz",
-      "integrity": "sha512-zT7wZyNYu3N5Bu0wuZ6QccIf93Qk1eV8LOewxgjOZFd2DenOs98cJ7+Y6703d0wkaXGY6/nZd4EweJaHz9uzQw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "axios": "^1.2.0",
+    "axios": "~1.1.3",
     "axios-logger": "^2.6.1",
     "debug": "^4.3.4",
     "form-data": "^4.0.0",


### PR DESCRIPTION
Since `axios-1.2.0` introduced a regression, we can't build it on
pure Node.js environment.

Until the upstream is fixed, we stick to `1.1`.

Close #130 