### PR TITLE
axios-log doesn't have a type compatibility with 1.2.4

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
     },
     {
       "matchPackageNames": ["axios"],
-      "allowedVersions": "<1.3.0"
+      "allowedVersions": "<=1.2.3"
     }
   ],
   "rangeStrategy": "bump",


### PR DESCRIPTION
https://github.com/autifyhq/autify-sdk-js/actions/runs/4169772806/jobs/7218084946

```
Error: src/debug.ts([13](https://github.com/autifyhq/autify-sdk-js/actions/runs/4169772806/jobs/7218084946#step:5:14),32): error TS2345: Argument of type '(request: AxiosRequestConfig<any>, config?: RequestLogConfig | undefined) => AxiosRequestConfig<any>' is not assignable to parameter of type '(value: InternalAxiosRequestConfig<any>) => InternalAxiosRequestConfig<any> | Promise<InternalAxiosRequestConfig<any>>'.
  Type 'AxiosRequestConfig<any>' is not assignable to type 'InternalAxiosRequestConfig<any> | Promise<InternalAxiosRequestConfig<any>>'.
    Type 'AxiosRequestConfig<any>' is not assignable to type 'InternalAxiosRequestConfig<any>'.
      Types of property 'headers' are incompatible.
        Type 'AxiosHeaders | (Partial<RawAxiosHeaders & { Accept: AxiosHeaderValue; "Content-Length": AxiosHeaderValue; "User-Agent": AxiosHeaderValue; "Content-Encoding": AxiosHeaderValue; Authorization: AxiosHeaderValue; } & { ...; }> & Partial<...>) | undefined' is not assignable to type 'AxiosRequestHeaders'.
          Type 'undefined' is not assignable to type 'AxiosRequestHeaders'.
            Type 'undefined' is not assignable to type 'Partial<RawAxiosHeaders & { Accept: AxiosHeaderValue; "Content-Length": AxiosHeaderValue; "User-Agent": AxiosHeaderValue; "Content-Encoding": AxiosHeaderValue; Authorization: AxiosHeaderValue; } & { ...; }>'.
```

I guess we can ignore this with `as any` hack though, let me avoid updating for now.

https://github.com/autifyhq/autify-sdk-js/blob/e92dad2d29156be2abf727dd0d78b769d081a3b4/src/debug.ts#L13

```typescript
axios.interceptors.request.use(requestLogger as any, errorLogger);
```