### PR TITLE
Disable axios update for now

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,8 +8,8 @@
       "groupName": "all non major npm update"
     },
     {
-      "matchPackageNames": ["axios"],
-      "allowedVersions": "<=1.2.3"
+      "enabled": false,
+      "matchPackageNames": ["axios"]
     }
   ],
   "rangeStrategy": "bump",


### PR DESCRIPTION
I noticed renovate updates lock file even it's not allowed

https://github.com/autifyhq/autify-sdk-js/pull/177#discussion_r1105262499

Let me disable axios update for now.