### PR TITLE
fix: check diff with native git command on Generate Web Client workflow

### DIFF
--- a/.github/workflows/generate-web-client.yml
+++ b/.github/workflows/generate-web-client.yml
@@ -21,9 +21,15 @@ jobs:
       - run: npm run format
       - run: npm run lint
       - id: check-diff
-        uses: technote-space/get-diff-action@v6
+        name: check for changes
+        run: |
+          if git diff --exit-code; then
+            echo "changes_exist=false" >> $GITHUB_OUTPUT
+          else
+            echo "changes_exist=true" >> $GITHUB_OUTPUT
+          fi
       - uses: peter-evans/create-pull-request@v5
-        if: steps.check-diff.outputs.diff
+        if: steps.check-diff.outputs.changes_exist == 'true'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "feat: update Web Client"


### PR DESCRIPTION
quit using technote-space/get-diff-action@v6 as it doesn't check the diff with `workflow_dispatch` event.

https://github.com/technote-space/get-diff-action/blob/eb3a04b9acda766a323ce182c0cb06e991d57326/src/constant.ts#L1-L10
