### PR TITLE
[PLAT-435] chore: enable to upgrade axios by renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,10 +6,6 @@
       "matchDatasources": ["npm"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non major npm update"
-    },
-    {
-      "enabled": false,
-      "matchPackageNames": ["axios"]
     }
   ],
   "rangeStrategy": "bump",


### PR DESCRIPTION
As the original issue https://github.com/autifyhq/autify-sdk-js/pull/176 is already solved `axios` upgrade by renovate is enabled again.