### PR TITLE
chore: updated nodejs versions on CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14, 16, 18]
+        node: [18, 20]
       fail-fast: false
     name: Node ${{ matrix.node }} build
     steps:
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14, 16, 18]
+        node: [18, 20]
       fail-fast: false
     name: Node ${{ matrix.node }} test
     steps:


### PR DESCRIPTION
Stop supporting Nodejs 14 & 18 and added 20 on CI.