### PR TITLE
Fix HTML escaped descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,10 +50,11 @@
     "generate:sdk-client": "ts-node scripts/generate.ts",
     "generate:client:web": "npm run update-swagger-web && npm run generate:openapi-client:web && npm run generate:sdk-client web",
     "generate:client:mobile": "npm run generate:openapi-client:mobile && npm run generate:sdk-client mobile",
-    "generate": "npm run generate:client:web && npm run generate:client:mobile && npm run lint && npm run format",
+    "generate": "npm run generate:client:web && npm run generate:client:mobile && npm run fix-html-escape && npm run lint && npm run format",
     "build": "shx rm -rf dist && tsc -b",
     "prepack": "npm run build",
     "lint": "eslint . --ext .ts",
+    "fix-html-escape": "bash scripts/fixHtmlEscape.sh",
     "format": "prettier --write '**/*.{md,json,yml,js,cjs,ts}'",
     "prepare": "husky install",
     "test": "jest test"

--- a/scripts/fixHtmlEscape.sh
+++ b/scripts/fixHtmlEscape.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/env bash
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  find src/generated -type f -exec sed -i '' -e "s/\\\&#39;/'/g" {} +
+else
+  find src/generated -type f -exec sed -i -e "s/\\\&#39;/'/g" {} +
+fi

--- a/src/generated/web/client.ts
+++ b/src/generated/web/client.ts
@@ -471,7 +471,7 @@ export class WebClient {
    * Update a url replacement for the test plan
    * @param {number} testPlanId For example, 15 for the following URL: https://app.autify.com/projects/1/test_plans/15
    * @param {number} testPlanVariableId test_plan_variable id
-   * @param {UpdateTestPlanVariableRequest} updateTestPlanVariableRequest The variable\&#39;s new key and/or default_value\&#39;s value to register
+   * @param {UpdateTestPlanVariableRequest} updateTestPlanVariableRequest The variable's new key and/or default_value's value to register
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof TestPlanVariableApi

--- a/src/generated/web/openapi/api.ts
+++ b/src/generated/web/openapi/api.ts
@@ -3528,7 +3528,7 @@ export const TestPlanVariableApiAxiosParamCreator = function (
      * Update a url replacement for the test plan
      * @param {number} testPlanId For example, 15 for the following URL: https://app.autify.com/projects/1/test_plans/15
      * @param {number} testPlanVariableId test_plan_variable id
-     * @param {UpdateTestPlanVariableRequest} updateTestPlanVariableRequest The variable\&#39;s new key and/or default_value\&#39;s value to register
+     * @param {UpdateTestPlanVariableRequest} updateTestPlanVariableRequest The variable's new key and/or default_value's value to register
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -3701,7 +3701,7 @@ export const TestPlanVariableApiFp = function (configuration?: Configuration) {
      * Update a url replacement for the test plan
      * @param {number} testPlanId For example, 15 for the following URL: https://app.autify.com/projects/1/test_plans/15
      * @param {number} testPlanVariableId test_plan_variable id
-     * @param {UpdateTestPlanVariableRequest} updateTestPlanVariableRequest The variable\&#39;s new key and/or default_value\&#39;s value to register
+     * @param {UpdateTestPlanVariableRequest} updateTestPlanVariableRequest The variable's new key and/or default_value's value to register
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -3798,7 +3798,7 @@ export const TestPlanVariableApiFactory = function (
      * Update a url replacement for the test plan
      * @param {number} testPlanId For example, 15 for the following URL: https://app.autify.com/projects/1/test_plans/15
      * @param {number} testPlanVariableId test_plan_variable id
-     * @param {UpdateTestPlanVariableRequest} updateTestPlanVariableRequest The variable\&#39;s new key and/or default_value\&#39;s value to register
+     * @param {UpdateTestPlanVariableRequest} updateTestPlanVariableRequest The variable's new key and/or default_value's value to register
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -3887,7 +3887,7 @@ export class TestPlanVariableApi extends BaseAPI {
    * Update a url replacement for the test plan
    * @param {number} testPlanId For example, 15 for the following URL: https://app.autify.com/projects/1/test_plans/15
    * @param {number} testPlanVariableId test_plan_variable id
-   * @param {UpdateTestPlanVariableRequest} updateTestPlanVariableRequest The variable\&#39;s new key and/or default_value\&#39;s value to register
+   * @param {UpdateTestPlanVariableRequest} updateTestPlanVariableRequest The variable's new key and/or default_value's value to register
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof TestPlanVariableApi


### PR DESCRIPTION
It seems openapi-generator's templates have a problem.

https://github.com/OpenAPITools/openapi-generator/issues/11349

I know this `sed` can't unescape all characters but for the quick fix I'd like to apply this change.