### PR TITLE
Add scenario name property to Mobile test result API

### DIFF
--- a/swagger-mobile.yml
+++ b/swagger-mobile.yml
@@ -248,6 +248,9 @@ paths:
                         id:
                           type: string
                           example: jx8tyj
+                        name:
+                          type: string
+                          example: Test Scenario Name
                         status:
                           type: string
                           example: passed


### PR DESCRIPTION
We updated the Mobile's API https://github.com/autifyhq/mobile-web/pull/4602
We added the scenario name to `/api/v1/projects/{project_id}/results/{id}`